### PR TITLE
Implement elements positioning option

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -86,6 +86,9 @@ async def main(message: cl.Message):
     await cl.Message(content=tool_res).send()
 ```
 
+You can display inline elements before the message content by passing
+`elements_position="above"` when creating the `cl.Message` instance.
+
 Now run it!
 
 ```sh

--- a/backend/chainlit/message.py
+++ b/backend/chainlit/message.py
@@ -3,10 +3,7 @@ import json
 import time
 import uuid
 from abc import ABC
-from typing import Dict, List, Optional, Union, cast
-
-from literalai.helper import utc_now
-from literalai.observability.step import MessageStepType
+from typing import Dict, List, Literal, Optional, Union, cast
 
 from chainlit.action import Action
 from chainlit.chat_context import chat_context
@@ -17,14 +14,10 @@ from chainlit.element import ElementBased
 from chainlit.logger import logger
 from chainlit.step import StepDict
 from chainlit.telemetry import trace_event
-from chainlit.types import (
-    AskActionResponse,
-    AskActionSpec,
-    AskFileResponse,
-    AskFileSpec,
-    AskSpec,
-    FileDict,
-)
+from chainlit.types import (AskActionResponse, AskActionSpec, AskFileResponse,
+                            AskFileSpec, AskSpec, FileDict)
+from literalai.helper import utc_now
+from literalai.observability.step import MessageStepType
 
 
 class MessageBase(ABC):
@@ -70,6 +63,7 @@ class MessageBase(ABC):
             type=type,  # type: ignore
             language=_dict.get("language"),
             metadata=_dict.get("metadata", {}),
+            elements_position=_dict.get("elementsPosition", "below"),
         )
 
     def to_dict(self) -> StepDict:
@@ -90,6 +84,7 @@ class MessageBase(ABC):
             "waitForAnswer": self.wait_for_answer,
             "metadata": self.metadata or {},
             "tags": self.tags,
+            "elementsPosition": self.elements_position,
         }
 
         return _dict
@@ -217,6 +212,7 @@ class Message(MessageBase):
         language: Optional[str] = None,
         actions: Optional[List[Action]] = None,
         elements: Optional[List[ElementBased]] = None,
+        elements_position: Literal["above", "below"] = "below",
         type: MessageStepType = "assistant_message",
         metadata: Optional[Dict] = None,
         tags: Optional[List[str]] = None,
@@ -259,6 +255,7 @@ class Message(MessageBase):
         self.type = type
         self.actions = actions if actions is not None else []
         self.elements = elements if elements is not None else []
+        self.elements_position = elements_position
 
         super().__post_init__()
 

--- a/backend/chainlit/step.py
+++ b/backend/chainlit/step.py
@@ -7,10 +7,6 @@ from copy import deepcopy
 from functools import wraps
 from typing import Callable, Dict, List, Optional, TypedDict, Union
 
-from literalai import BaseGeneration
-from literalai.helper import utc_now
-from literalai.observability.step import StepType, TrueStepType
-
 from chainlit.config import config
 from chainlit.context import CL_RUN_NAMES, context, local_steps
 from chainlit.data import get_data_layer
@@ -18,6 +14,9 @@ from chainlit.element import Element
 from chainlit.logger import logger
 from chainlit.telemetry import trace_event
 from chainlit.types import FeedbackDict
+from literalai import BaseGeneration
+from literalai.helper import utc_now
+from literalai.observability.step import StepType, TrueStepType
 
 
 def check_add_step_in_cot(step: "Step"):
@@ -65,6 +64,7 @@ class StepDict(TypedDict, total=False):
     defaultOpen: Optional[bool]
     language: Optional[str]
     feedback: Optional[FeedbackDict]
+    elementsPosition: Optional[str]
 
 
 def flatten_args_kwargs(func, args, kwargs):

--- a/frontend/src/components/chat/Messages/Message/Content/index.tsx
+++ b/frontend/src/components/chat/Messages/Message/Content/index.tsx
@@ -92,10 +92,17 @@ const MessageContent = memo(
       </div>
     );
 
+    const elementsFirst = message.elementsPosition === 'above';
+
     return (
       <div className="message-content w-full flex flex-col gap-2">
+        {elementsFirst ? (
+          <InlinedElements elements={outputInlinedElements} />
+        ) : null}
         {!!inputMarkdown || output ? markdownContent : null}
-        <InlinedElements elements={outputInlinedElements} />
+        {!elementsFirst ? (
+          <InlinedElements elements={outputInlinedElements} />
+        ) : null}
       </div>
     );
   }

--- a/frontend/src/components/chat/Messages/Message/UserMessage.tsx
+++ b/frontend/src/components/chat/Messages/Message/UserMessage.tsx
@@ -58,7 +58,9 @@ export default function UserMessage({
 
   return (
     <div className="flex flex-col w-full gap-1">
-      <InlinedElements elements={inlineElements} className="items-end" />
+      {message.elementsPosition === 'above' ? (
+        <InlinedElements elements={inlineElements} className="items-end" />
+      ) : null}
 
       <div className="flex flex-row items-center gap-1 w-full group">
         {!isEditing && editable && (
@@ -118,6 +120,9 @@ export default function UserMessage({
           )}
         </div>
       </div>
+      {message.elementsPosition !== 'above' ? (
+        <InlinedElements elements={inlineElements} className="items-end" />
+      ) : null}
     </div>
   );
 }

--- a/libs/react-client/src/types/step.ts
+++ b/libs/react-client/src/types/step.ts
@@ -33,6 +33,7 @@ export interface IStep {
   streaming?: boolean;
   steps?: IStep[];
   metadata?: Record<string, any>;
+  elementsPosition?: 'above' | 'below';
   //legacy
   indent?: number;
 }


### PR DESCRIPTION
## Summary
- allow customizing the order of inline elements in messages
- surface `elements_position` parameter in the Python API
- update StepDict and frontend message types
- support rendering elements above or below content in the UI
- document the new option

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_683d734ee5e08323a4b4b7a808b45e4b

## Summary by Sourcery

Implement an option to customize positioning of inline message elements by exposing a new parameter in the Python API, extending message schemas and types, updating the frontend to honor the setting, and adding documentation.

New Features:
- Expose `elements_position` parameter in Python Message API to allow specifying inline element order
- Add `elementsPosition` property to message StepDict and TypeScript step types
- Implement UI logic to render inline elements above or below message content based on the new option
- Document the `elements_position` option in backend README