### PR TITLE
Add dataframe page size option

### DIFF
--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -60,6 +60,7 @@ class ElementDict(TypedDict, total=False):
     size: Optional[ElementSize]
     language: Optional[str]
     page: Optional[int]
+    pageSize: Optional[int]
     props: Optional[Dict]
     autoPlay: Optional[bool]
     playerConfig: Optional[dict]
@@ -120,6 +121,7 @@ class Element:
                 "size": getattr(self, "size", None),
                 "props": getattr(self, "props", None),
                 "page": getattr(self, "page", None),
+                "pageSize": getattr(self, "page_size", None),
                 "autoPlay": getattr(self, "auto_play", None),
                 "playerConfig": getattr(self, "player_config", None),
                 "language": getattr(self, "language", None),
@@ -429,6 +431,7 @@ class Dataframe(Element):
     type: ClassVar[ElementType] = "dataframe"
     size: ElementSize = "large"
     data: Any = None  # The type is Any because it is checked in __post_init__.
+    page_size: Optional[int] = None
 
     def __post_init__(self) -> None:
         """Ensures the data is a pandas DataFrame and converts it to JSON."""

--- a/cypress/e2e/dataframe/main.py
+++ b/cypress/e2e/dataframe/main.py
@@ -63,6 +63,6 @@ async def start():
 
     df = pd.DataFrame(data)
 
-    elements = [cl.Dataframe(data=df, display="inline", name="Dataframe")]
+    elements = [cl.Dataframe(data=df, display="inline", name="Dataframe", page_size=5)]
 
     await cl.Message(content="This message has a Dataframe", elements=elements).send()

--- a/cypress/e2e/dataframe/spec.cy.ts
+++ b/cypress/e2e/dataframe/spec.cy.ts
@@ -9,5 +9,10 @@ describe('dataframe', () => {
     // Check if the DataFrame is rendered within the first step
     cy.get('.step').should('have.length', 1);
     cy.get('.step').first().find('.dataframe').should('have.length', 1);
+    // Check that only 5 rows are visible per page
+    cy.get('.step')
+      .first()
+      .find('.dataframe tbody tr')
+      .should('have.length', 5);
   })
 });

--- a/frontend/src/components/Elements/Dataframe.tsx
+++ b/frontend/src/components/Elements/Dataframe.tsx
@@ -38,7 +38,7 @@ interface DataframeData {
   data: (string | number)[][];
 }
 
-const _DataframeElement = ({ data }: { data: DataframeData }) => {
+const _DataframeElement = ({ data, pageSize }: { data: DataframeData; pageSize?: number }) => {
   const { index, columns, data: rowData } = data;
 
   const tableColumns: ColumnDef<Record<string, string | number>>[] = useMemo(
@@ -81,7 +81,7 @@ const _DataframeElement = ({ data }: { data: DataframeData }) => {
     getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
     initialState: {
-      pagination: { pageSize: 10 }
+      pagination: { pageSize: pageSize || 10 }
     }
   });
 
@@ -193,7 +193,7 @@ function DataframeElement({ element }: { element: IDataframeElement }) {
     return <Alert variant="error">{error.message}</Alert>;
   }
 
-  return <_DataframeElement data={jsonData} />;
+  return <_DataframeElement data={jsonData} pageSize={element.pageSize} />;
 }
 
 export default DataframeElement;

--- a/libs/react-client/src/types/element.ts
+++ b/libs/react-client/src/types/element.ts
@@ -74,7 +74,9 @@ export type IPlotlyElement = TMessageElement<'plotly'>;
 
 export type ITasklistElement = TElement<'tasklist'>;
 
-export type IDataframeElement = TMessageElement<'dataframe'>;
+export interface IDataframeElement extends TMessageElement<'dataframe'> {
+  pageSize?: number;
+}
 
 export interface ICustomElement extends TMessageElement<'custom'> {
   props: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- support `pageSize` parameter on dataframe element
- wire page size through frontend table
- test new dataframe pagination via cypress

## Testing
- `pnpm lint` *(fails: ESLint couldn't find eslint.config.js)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_683f1f25b25c83239d92c3fbabaa97f9

## Summary by Sourcery

Enable customizable pagination for Dataframe elements by introducing a pageSize option, wiring it through the backend, type definitions, frontend component, and end-to-end tests.

New Features:
- Add support for a pageSize parameter on Dataframe elements to customize rows per page

Enhancements:
- Propagate pageSize through the backend element model, client type definitions, and React Dataframe component pagination state

Tests:
- Update Cypress tests to assert that only the configured number of rows (5) render per page and configure page_size=5 in the test setup